### PR TITLE
Top negative authors

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,8 @@
         <button class="tab-button" data-tab="totalCommentsTab">Comments per Post</button>
         <button class="tab-button" data-tab="engagementTab">Engagement Score per Post</button>
         <button class="tab-button" data-tab="topPosts">Top 10 Posts</button>
+        <button class="tab-button" data-tab="authorsTab">Author Stats</button>
+
       </div>
 
       <section id="weightedTab" class="chart-section tab-content active">
@@ -194,7 +196,7 @@
       </section>
 
 
-      <section id="topPosts" class="chart-section tab-content" style="display:none;">
+    <section id="topPosts" class="chart-section tab-content" style="display:none;">
       <div class="card" style="flex:1; display:flex; flex-direction:column;">
         <!-- <h2>Post List</h2> -->
         <label for="postListDropdown"><b>Select Criteria:</b></label>
@@ -209,7 +211,16 @@
   
         <div id="postListContainer"></div>
       </div>
+    
     </section>
+
+    <section id="authorsTab" class="chart-section tab-content" style="display:none;">
+      <canvas id="authorsChart"></canvas>
+      <p style="font-size:small; text-align:left; max-width:1200px; margin:5px auto;">
+        This chart shows the top 10 authors with the most negative total sentiments.
+      </p>
+    </section>
+    
 
     </div>
 

--- a/script.js
+++ b/script.js
@@ -796,6 +796,92 @@ document.addEventListener('DOMContentLoaded', async () => {
     return html;
   }
 
+  // New function to fetch authors from Firestore
+  async function fetchAuthorStats() {
+    const authorsSnapshot = await getDocs(collection(db, 'authors'));
+    let authorArray = [];
+    authorsSnapshot.forEach(doc => {
+      const data = doc.data();
+      data.author = doc.id; // use the document ID as the author name
+      authorArray.push(data);
+    });
+    // Sort by negativeCount descending.
+    authorArray.sort((a, b) => b.negativeCount - a.negativeCount);
+
+    // Return top 10 negative authors
+    return authorArray.slice(0, 10);
+  }
+
+  // New function to render the authors bar chart
+  function renderAuthorsChart(data) {
+    const labels = data.map(item => item.author);
+    const negativeCount = data.map(item => item.negativeCount);
+
+    // Use red if the average sentiment is negative, green if positive
+    const backgroundColors = negativeCount.map(() => 'rgba(255, 99, 132, 0.8)');
+
+
+    if (window.authorsChartInstance) {
+      window.authorsChartInstance.destroy();
+    }
+
+    const ctx = document.getElementById('authorsChart').getContext('2d');
+    window.authorsChartInstance = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Total Negative Sentiments',
+          data: negativeCount,
+          backgroundColor: backgroundColors,
+        }]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          title: {
+            display: true,
+            text: 'Top 10 Authors with Most Negative Sentiments',
+            align: 'start',
+            font: {
+              size: 18,
+              weight: '600',
+              family: 'Arial, sans-serif'
+            },
+            color: '#333',
+            padding: { top: 10, bottom: 20 }
+          },
+          tooltip: {
+            callbacks: {
+              label: function(context) {
+                return `${context.label}: ${context.raw.toFixed(2)}`;
+              }
+            }
+          }
+        },
+        scales: {
+          y: { beginAtZero: false }
+        },
+        onClick: (evt, elements) => {
+          if (elements.length > 0) {
+            const authorName = labels[elements[0].index];
+            alert(`Author: ${authorName}`);
+          }
+        }
+      }
+    });
+  }
+
+  // New function to update the authors chart
+  async function updateAuthorsChart() {
+    try {
+      const authorData = await fetchAuthorStats();
+      renderAuthorsChart(authorData);
+    } catch (error) {
+      console.error("Error updating authors chart:", error);
+    }
+  }
+
   async function updateCharts() {
     try {
       allPostsData = await fetchPostsInRange();
@@ -878,6 +964,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         renderEngagementScoreChart(allPostsData);
       } else if (tabId === 'totalCommentsTab') {
         renderCommentsCountChart(allPostsData);
+      } else if (tabId === 'authorsTab') {
+        updateAuthorsChart();
       }
     });
   });

--- a/script.js
+++ b/script.js
@@ -812,14 +812,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     return authorArray.slice(0, 10);
   }
 
-  // New function to render the authors bar chart
+  // New function to render the authors stacked bar chart
   function renderAuthorsChart(data) {
     const labels = data.map(item => item.author);
-    const negativeCount = data.map(item => item.negativeCount);
-
-    // Use red if the average sentiment is negative, green if positive
-    const backgroundColors = negativeCount.map(() => 'rgba(255, 99, 132, 0.8)');
-
+    const positiveCounts = data.map(item => item.positiveCount);
+    const negativeCounts = data.map(item => item.negativeCount);
 
     if (window.authorsChartInstance) {
       window.authorsChartInstance.destroy();
@@ -830,11 +827,18 @@ document.addEventListener('DOMContentLoaded', async () => {
       type: 'bar',
       data: {
         labels: labels,
-        datasets: [{
-          label: 'Total Negative Sentiments',
-          data: negativeCount,
-          backgroundColor: backgroundColors,
-        }]
+        datasets: [
+          {
+            label: 'Positive Count',
+            data: positiveCounts,
+            backgroundColor: 'rgba(75, 192, 192, 0.8)', // green
+          },
+          {
+            label: 'Negative Count',
+            data: negativeCounts,
+            backgroundColor: 'rgba(255, 99, 132, 0.8)', // red
+          }
+        ]
       },
       options: {
         responsive: true,
@@ -854,13 +858,24 @@ document.addEventListener('DOMContentLoaded', async () => {
           tooltip: {
             callbacks: {
               label: function(context) {
-                return `${context.label}: ${context.raw.toFixed(2)}`;
+                return `${context.dataset.label}: ${context.raw}`;
               }
             }
           }
         },
         scales: {
-          y: { beginAtZero: false }
+          x: {
+            stacked: true,
+            ticks: {
+              maxRotation: 60,
+              minRotation: 60,
+              align: 'center'
+            }
+          },
+          y: {
+            stacked: true,
+            beginAtZero: true
+          }
         },
         onClick: (evt, elements) => {
           if (elements.length > 0) {
@@ -871,6 +886,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
     });
   }
+
 
   // New function to update the authors chart
   async function updateAuthorsChart() {

--- a/update_author_aggregation.py
+++ b/update_author_aggregation.py
@@ -1,0 +1,118 @@
+'''
+1. Reads all posts and comments from Firestore.
+2. Aggregates sentiment statistics per author.
+3. Saves these aggregated results under a new authors collection in Firestore.
+
+authors (collection)
+ └─ {username} (document)
+     ├─ totalSentimentScore (float)
+     ├─ postCount (int)
+     ├─ commentCount (int)
+     ├─ negativeCount (int)
+     ├─ positiveCount (int)
+     ├─ averageSentiment (float)
+
+'''
+import os
+import firebase_admin
+from firebase_admin import credentials, firestore
+import logging
+
+# Setup logging to file
+logging.basicConfig(filename='author_aggregation_errors.log', 
+                    level=logging.ERROR,
+                    format='%(asctime)s %(levelname)s: %(message)s')
+
+# Initialize Firebase Firestore
+cred = credentials.Certificate("firebase-credentials.json")
+firebase_admin.initialize_app(cred)
+db = firestore.client()
+
+# Author statistics dictionary
+author_stats = {}
+
+# Process posts
+def process_posts():
+    posts = db.collection("posts").stream()
+    for post_doc in posts:
+        post = post_doc.to_dict()
+        author = post.get("author", "Unknown")
+        sentiment = post.get("sentiment", 0)
+
+        if author not in author_stats:
+            author_stats[author] = {
+                "totalSentimentScore": 0,
+                "postCount": 0,
+                "commentCount": 0,
+                "negativeCount": 0,
+                "positiveCount": 0
+            }
+
+        # Update stats for the post author
+        author_stats[author]["totalSentimentScore"] += sentiment
+        author_stats[author]["postCount"] += 1
+        
+        if sentiment < 0:
+            author_stats[author]["negativeCount"] += 1
+        elif sentiment > 0:
+            author_stats[author]["positiveCount"] += 1
+
+# Process comments
+def process_comments():
+    posts = db.collection("posts").stream()
+    for post_doc in posts:
+        post_id = post_doc.id
+        comments = db.collection("posts").document(post_id).collection("comments").stream()
+
+        for comment_doc in comments:
+            comment = comment_doc.to_dict()
+            author = comment.get("author", "Unknown")
+            sentiment = comment.get("sentiment", 0)
+
+            if author not in author_stats:
+                author_stats[author] = {
+                    "totalSentimentScore": 0,
+                    "postCount": 0,
+                    "commentCount": 0,
+                    "negativeCount": 0,
+                    "positiveCount": 0
+                }
+
+            # Update stats for the comment author
+            author_stats[author]["totalSentimentScore"] += sentiment
+            author_stats[author]["commentCount"] += 1
+            
+            if sentiment < 0:
+                author_stats[author]["negativeCount"] += 1
+            elif sentiment > 0:
+                author_stats[author]["positiveCount"] += 1
+
+# Save to Firestore
+def save_to_firestore():
+    for author, stats in author_stats.items():
+        try:
+            total_comments = stats.get("commentCount", 0)
+            total_posts = stats.get("postCount", 0)
+            total_interactions = total_comments + total_posts
+
+            # Calculate average sentiment
+            if total_interactions > 0:
+                stats["averageSentiment"] = stats["totalSentimentScore"] / total_interactions
+            else:
+                stats["averageSentiment"] = 0
+
+            # Save to Firestore
+            db.collection("authors").document(author).set(stats)
+
+            print(f"Saved stats for author: {author}")
+        except Exception as e:
+            logging.error(f"Error saving author stats for {author}: {e}")
+
+if __name__ == "__main__":
+    print("Starting author aggregation...")
+
+    process_posts()
+    process_comments()
+    save_to_firestore()
+
+    print("Author aggregation completed successfully!")


### PR DESCRIPTION
This update introduces a new feature to the dashboard that displays author sentiment statistics using a stacked bar chart. The chart aggregates data from the Firestore “authors” collection, sorting authors in descending order by their negative sentiment count. It visualizes positive sentiment counts (in green) and negative sentiment counts (in red) for each author, providing a clear breakdown of their contributions. This enhancement will help us monitor which users are generating the most negative feedback and enable a more nuanced analysis of community sentiment trends.