### PR TITLE
Feature/responsive mobile layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -243,6 +243,50 @@
              content: none; /* Remove bullets for tech stack */
          }
 
+    /* --- Responsive: phones and small tablets --- */
+    @media (max-width: 768px) {
+        body {
+            padding: 1.25rem 1rem;
+            line-height: 1.65;
+        }
+
+        h1 { font-size: clamp(1.5rem, 6vw, 2.4rem); }
+        h2 { font-size: clamp(1.25rem, 5vw, 1.8rem); margin-top: 2rem; }
+        h3 { font-size: clamp(1.1rem, 4.5vw, 1.4rem); margin-top: 1.6rem; }
+        h4 { font-size: 1.05rem; }
+
+        /* Wide comparison tables scroll rather than squash to unreadable columns. */
+        table {
+            display: block;
+            width: 100%;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            white-space: normal;
+        }
+
+        th, td {
+            padding: 0.65rem 0.75rem;
+            font-size: 0.92rem;
+            min-width: 8rem;
+        }
+
+        blockquote {
+            padding: 0.9rem 1rem;
+            margin: 1.2rem 0;
+        }
+
+        ul, ol { padding-left: 1.4rem; }
+
+        img { margin: 1.2rem auto; }
+
+        hr { width: 100%; margin: 2rem auto; }
+
+        h2:last-of-type + p { padding: 1rem; }
+
+        /* Keep long URLs and code spans from widening the page. */
+        p, li, td, code { overflow-wrap: anywhere; }
+    }
+
   </style>
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -2,8 +2,23 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
-  <title>About - r/TemasekPoly Sentiment Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About - Polytechnic Sentiments Dashboard</title>
+
+  <!--
+      Follow the dashboard's theme switch. Runs before the body paints so a
+      dark-theme user never sees a white flash. Key is shared with index.html.
+  -->
+  <script>
+    (function () {
+      try {
+        if (localStorage.getItem('tpcraw-theme') === 'dark') {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      } catch (e) { /* storage blocked (private mode) — stay on light */ }
+    })();
+  </script>
+
   <style>
     /* --- Reset and Base Styles --- */
     body {
@@ -287,11 +302,147 @@
         p, li, td, code { overflow-wrap: anywhere; }
     }
 
+    /* --- Highlighted search term (matches the dashboard's own style) --- */
+    mark {
+        background-color: #fcf8e3;
+        color: #8a6d3b;
+        padding: 0.1em 0.2em;
+        border-radius: 3px;
+        font-weight: 600;
+    }
+
+    /* --- Back to dashboard bar --- */
+    .back-bar {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background-color: #f9fafb; /* match body so content can't show through */
+        padding: 0.75rem 0;
+        margin-bottom: 0.5rem;
+        border-bottom: 1px solid #e9ecef;
+    }
+    .back-bar a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-height: 44px; /* comfortable tap target */
+        padding: 0 0.9rem;
+        background-color: #0d6efd;
+        color: #fff;
+        border-radius: 6px;
+        font-weight: 500;
+        text-decoration: none;
+    }
+    .back-bar a:hover {
+        background-color: #0a58ca;
+        color: #fff;
+        text-decoration: none;
+    }
+
+    /* =========================================================
+       Dark theme — mirrors the dashboard's toggle via the
+       shared `tpcraw-theme` key (see the <script> in <head>).
+       Additive overrides only; light styles above are untouched.
+       ========================================================= */
+
+    :root[data-theme="dark"] body {
+        background-color: #1a1a1a;
+        color: #e0e0e0;
+    }
+    :root[data-theme="dark"] h1 { color: #7fb2ff; border-bottom-color: #3a3a3a; }
+    :root[data-theme="dark"] h2 { color: #5b9dff; border-bottom-color: #2f2f2f; }
+    :root[data-theme="dark"] h3 { color: #d6d6d6; }
+    :root[data-theme="dark"] h4 { color: #bdbdbd; }
+    :root[data-theme="dark"] p  { color: #c9c9c9; }
+    :root[data-theme="dark"] li { color: #c9c9c9; }
+    :root[data-theme="dark"] strong { color: #f0f0f0; }
+
+    :root[data-theme="dark"] a       { color: #6ea8ff; }
+    :root[data-theme="dark"] a:hover { color: #9cc4ff; }
+
+    :root[data-theme="dark"] code {
+        background-color: #262b33;
+        color: #b8c7db;
+        border-color: #3a4351;
+    }
+
+    :root[data-theme="dark"] img {
+        border-color: #3a3a3a;
+        box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+    }
+
+    :root[data-theme="dark"] table {
+        border-color: #3a3a3a;
+        box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+    }
+    :root[data-theme="dark"] th {
+        background-color: #262626;
+        color: #d6d6d6;
+        border-bottom-color: #3a3a3a;
+    }
+    :root[data-theme="dark"] td {
+        color: #c9c9c9;
+        border-bottom-color: #3a3a3a;
+    }
+    :root[data-theme="dark"] tbody tr:nth-child(odd) { background-color: #1f1f1f; }
+    :root[data-theme="dark"] tbody tr:hover          { background-color: #2b2b2b; }
+
+    :root[data-theme="dark"] blockquote {
+        background-color: #242424;
+        color: #c9c9c9;
+        border-left-color: #17a2b8;
+    }
+    :root[data-theme="dark"] blockquote strong { color: #4fc3d7; }
+
+    :root[data-theme="dark"] hr { border-top-color: #3a3a3a; }
+
+    :root[data-theme="dark"] .tech-stack-list li {
+        background-color: #2c2c2c;
+        color: #d0d0d0;
+    }
+    :root[data-theme="dark"] .tech-stack-list li:hover {
+        background-color: #444;
+        color: #fff;
+    }
+
+    /* Disclaimer callout */
+    :root[data-theme="dark"] h2:last-of-type + p {
+        background-color: #3a3223;
+        border-color: #5c4d2a;
+        border-left-color: #ffc107;
+        color: #f0dfae;
+    }
+    :root[data-theme="dark"] h2:last-of-type + p strong { color: #ffd766; }
+
+    :root[data-theme="dark"] .back-bar {
+        background-color: #1a1a1a;
+        border-bottom-color: #333;
+    }
+    /* Must be re-stated: the generic dark `a` rule above has equal or higher
+       specificity and would otherwise turn this into blue text on blue. */
+    :root[data-theme="dark"] .back-bar a {
+        background-color: #1b5fd0;
+        color: #fff;
+    }
+    :root[data-theme="dark"] .back-bar a:hover {
+        background-color: #2b74e8;
+        color: #fff;
+    }
+
+    :root[data-theme="dark"] mark {
+        background-color: #4a4020;
+        color: #f0dfae;
+    }
+
   </style>
 </head>
 <body>
 
-  <h1>About - r/TemasekPoly Sentiment Dashboard</h1>
+  <nav class="back-bar">
+    <a href="index.html">&larr; Back to Dashboard</a>
+  </nav>
+
+  <h1>About - Polytechnic Sentiments Dashboard</h1>
 
   <p>
     <a href="https://shamim-akhtar.github.io/tpcraw/">
@@ -300,10 +451,11 @@
   </p>
 
   <p>
-    TPCraw is a Python-based project that crawls posts and comments from the
-    <code>r/TemasekPoly</code> subreddit and then analyzes them using Google’s Generative AI (Gemini).
+    TPCraw is a Python-based project that crawls posts and comments from Singapore's
+    polytechnic subreddits and then analyzes them using Google’s Generative AI (Gemini).
     The project produces sentiment analyses, summaries, and visualizations (via a web-based dashboard)
-    to gain insights into discussions about Temasek Polytechnic on Reddit.
+    to gain insights into discussions about the polytechnics on Reddit, with a particular focus on
+    Temasek Polytechnic.
   </p>
 
   <p>
@@ -315,7 +467,9 @@
   <h2>📌 About This App</h2>
   <p>
     This application is a tool designed to gather, process, and visualize user-generated content from
-    the Reddit community <code>r/TemasekPoly</code>. It consists of two major components:
+    Reddit's Singapore polytechnic communities — <code>r/TemasekPoly</code>, <code>r/nanyangpoly</code>,
+    <code>r/republicpolytechnic</code>, <code>r/SingaporePoly</code>, <code>r/NgeeAnnPoly</code>,
+    <code>r/nyp</code> and <code>r/sgExams</code>. It consists of two major components:
   </p>
 
   <ol>
@@ -347,17 +501,20 @@
             <ul class="tech-stack-list">
                  <li>HTML</li>
                  <li>CSS (including styles for light/dark themes)</li>
+                 <li>CSS (responsive layer for phones and tablets)</li>
                  <li>JavaScript (Modular ES6)</li>
                  <li>Chart.js</li>
                  <li>Chart.js Zoom Plugin</li>
                  <li>chartjs-adapter-date-fns</li>
                  <li>Firebase SDK (v9 Modular)</li>
+                 <li>html2pdf.js</li>
             </ul>
   <p>
     The Frontend Dashboard is a dynamic and user-friendly web interface built with
     <strong>HTML, CSS, and JavaScript</strong>. It serves as the primary visualization tool
     for the data collected by the Python crawler. Users can interact with various charts, tables,
-    and filtering options to explore sentiment analysis results from <code>r/TemasekPoly</code>.
+    and filtering options to explore sentiment analysis results from whichever polytechnic
+    subreddit they select.
   </p>
   <p>
     This dashboard allows users to:
@@ -367,8 +524,13 @@
     <li>📊 Analyze positive, neutral, and negative sentiments through <strong>charts and graphs</strong>.</li>
     <li>📅 Track sentiment changes over time using <strong>time series visualizations</strong>.</li>
     <li>🔍 Filter posts based on specific criteria like date range, categories, and IIT relevance.</li>
+    <li>🏫 Switch between <strong>seven polytechnic subreddits</strong> without reloading the page.</li>
+    <li>🔎 <strong>Search by keyword</strong> across post and comment text.</li>
     <li>📈 Examine top authors based on their sentiment contributions (positive and negative).</li>
     <li>💬 Inspect individual posts and their associated comments to understand user feedback better.</li>
+    <li>📄 <strong>Export any post's analysis to PDF</strong> for sharing or reporting.</li>
+    <li>🌗 Switch between <strong>light and dark themes</strong>, remembered across visits.</li>
+    <li>📱 Use the whole dashboard on a <strong>phone or tablet</strong> as well as a desktop.</li>
   </ul>
 
   <p>
@@ -382,6 +544,54 @@
   <hr />
 
   <h2>Frontend Dashboard Features</h2>
+
+  <h3>🏫 Select Subreddit</h3>
+  <p>
+    The <strong>Select Subreddit</strong> dropdown, at the top of the left-hand column, controls
+    which community the entire dashboard reports on. Changing it reloads every chart, table and
+    metric on the page against that subreddit's data — no page refresh required.
+  </p>
+  <table>
+    <thead>
+      <tr>
+        <th>Option</th>
+        <th>Subreddit</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td><strong>Temasek Poly</strong></td><td><code>r/TemasekPoly</code> (default)</td></tr>
+      <tr><td><strong>Nanyang Poly</strong></td><td><code>r/nanyangpoly</code></td></tr>
+      <tr><td><strong>Republic Poly</strong></td><td><code>r/republicpolytechnic</code></td></tr>
+      <tr><td><strong>Singapore Poly</strong></td><td><code>r/SingaporePoly</code></td></tr>
+      <tr><td><strong>Ngee Ann Poly</strong></td><td><code>r/NgeeAnnPoly</code></td></tr>
+      <tr><td><strong>Nanyang Poly Students</strong></td><td><code>r/nyp</code></td></tr>
+      <tr><td><strong>SGExams</strong></td><td><code>r/sgExams</code></td></tr>
+    </tbody>
+  </table>
+  <p>
+    Some filters are specific to a community, so the dashboard shows and hides them as you switch.
+    The <strong>IIT</strong> checkbox applies only to <code>r/TemasekPoly</code>, and the
+    <strong>TP-Related?</strong> checkbox applies only to <code>r/sgExams</code>, where posts cover
+    every institution and most are unrelated to Temasek Polytechnic.
+  </p>
+
+  <hr />
+
+  <h3>🔎 Keyword Search</h3>
+  <p>
+    The <strong>Keyword Search</strong> box searches the text of posts and comments in the selected
+    subreddit and date range, rather than filtering the charts. Results open in the details panel,
+    split into matching posts and matching comments, with the search term
+    <mark>highlighted</mark> in each excerpt.
+  </p>
+  <ul>
+    <li>Press <strong>Enter</strong> or click <strong>Search</strong> to run a search.</li>
+    <li>Each result carries the same sentiment, emotion and category badges used elsewhere.</li>
+    <li>Comment results show the parent post's title, so you keep the context of the thread.</li>
+    <li>Use <strong>View Full Post</strong> on any result to jump to that post's complete analysis.</li>
+  </ul>
+
+  <hr />
 
   <h3>📅 Date Range & IIT Filter</h3>
   <p>
@@ -410,6 +620,10 @@
       <tr>
         <td><strong>IIT Checkbox</strong></td>
         <td>A checkbox option allows users to filter posts specifically related to the <em>School of Informatics & IT (IIT)</em>. When enabled, only posts marked with a relevance flag (<code>iit: "yes"</code>) are displayed. This is particularly useful for examining feedback or discussions directly related to IIT courses or facilities. Results may not be very accurate as we are using Gen AI to categorize whether or not a post is associated with IIT.</td>
+      </tr>
+      <tr>
+        <td><strong>TP-Related? Checkbox</strong></td>
+        <td>Shown only when <code>r/sgExams</code> is selected. That subreddit covers every institution in Singapore, so this filter narrows results to posts the crawler flagged as mentioning Temasek Polytechnic (<code>relatedToTemasekPoly: true</code>). As with the IIT flag, the classification comes from Gen AI and may occasionally misfire.</td>
       </tr>
       <tr>
         <td><strong>Filter Button</strong></td>
@@ -710,9 +924,70 @@
     <li><strong>Summary</strong>: A concise summary of the post and its comments generated by the Google Gemini AI.</li>
     <li><strong>Comments List</strong>: A detailed list of all comments related to the post, along with sentiment scores, emotions, categories, and IIT relevance.</li>
   </ul>
+  <p><strong>Export to PDF:</strong></p>
+  <ul>
+    <li>The details panel carries a <strong>Download PDF</strong> button that renders the whole analysis — title, metadata, badges, AI summary, post body and every comment — into <code>TPCraw_Analysis_Report.pdf</code>.</li>
+    <li>Navigation and action buttons are hidden from the capture, so the report contains only the content.</li>
+    <li>Useful for circulating a single post's analysis to staff who don't use the dashboard directly.</li>
+  </ul>
   <p>
     The <strong>Post Details Display</strong> feature provides a comprehensive breakdown of each post,
     making it easy to dive into individual conversations and analyze specific interactions.
+  </p>
+
+  <hr />
+
+  <h3>🌗 Light & Dark Themes</h3>
+  <p>
+    The switch in the top-right corner of the dashboard toggles between the light and dark
+    stylesheets. Your choice is saved in the browser's local storage, so the dashboard opens in the
+    same theme on your next visit, and this About page follows the same setting.
+  </p>
+  <p>
+    The theme is applied before the page renders, so switching to dark does not produce a white
+    flash on load. If your browser blocks local storage (private browsing, for example), the theme
+    still works for the current session but will not be remembered.
+  </p>
+
+  <hr />
+
+  <h3>📱 Works on Any Device</h3>
+  <p>
+    The dashboard adapts to the screen it is opened on, from a desktop monitor down to a phone in
+    portrait orientation.
+  </p>
+  <table>
+    <thead>
+      <tr>
+        <th>Screen</th>
+        <th>Behaviour</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Desktop</strong><br />wider than 1024px</td>
+        <td>The original two-column layout: summary metrics and the sentiment pie on the left, the tabbed charts on the right.</td>
+      </tr>
+      <tr>
+        <td><strong>Tablet</strong><br />up to 1024px</td>
+        <td>Collapses to a single column, with the summary cards rearranged into a grid above the charts. The tab bar becomes a horizontally swipeable strip instead of wrapping onto several rows.</td>
+      </tr>
+      <tr>
+        <td><strong>Phone</strong><br />up to 768px</td>
+        <td>Filter controls stack full width, charts are given a taller fixed height so the plot area stays readable, axis labels shorten and thin out, chart legends move below the plot, and the post details panel opens full screen.</td>
+      </tr>
+    </tbody>
+  </table>
+  <p><strong>Touch gestures:</strong></p>
+  <ul>
+    <li><strong>Pinch</strong> to zoom into a chart.</li>
+    <li><strong>Drag sideways</strong> to pan across it. Vertical swipes still scroll the page normally.</li>
+    <li><strong>Tap</strong> a bar or data point to open that post's details.</li>
+    <li>On a desktop the original gestures are unchanged: drag to zoom, <strong>Ctrl</strong> + drag to pan.</li>
+  </ul>
+  <p>
+    Rotating a phone between portrait and landscape re-renders the charts at the new size using data
+    already loaded, so no additional queries are made.
   </p>
 
   <hr />
@@ -727,12 +1002,20 @@
 
   <h3>🚀 Automated Data Collection</h3>
   <p>
-    The crawler component of the application continuously collects user-generated content from
-    the subreddit <code>r/TemasekPoly</code> on Reddit. It fetches both <strong>posts and comments</strong>
+    The crawler component of the application continuously collects user-generated content from the
+    polytechnic subreddits on Reddit. The list of communities it visits is read from
+    <code>subreddits.txt</code>, so adding or removing one is a configuration change rather than a
+    code change. It fetches both <strong>posts and comments</strong>
     using the PRAW (Python Reddit API Wrapper). This automated data gathering ensures that the application
-    stays up-to-date with the latest discussions, feedback, and trends related to Temasek Polytechnic.
+    stays up-to-date with the latest discussions, feedback, and trends related to the polytechnics.
     The crawler retrieves a maximum of 500 recent posts and their associated comments each time it runs,
     providing a comprehensive dataset for further analysis.
+  </p>
+  <p>
+    For the broader <code>r/sgExams</code> community, the crawler additionally detects whether each
+    post or comment actually mentions Temasek Polytechnic and records that as a
+    <code>relatedToTemasekPoly</code> flag, which is what the dashboard's
+    <strong>TP-Related?</strong> filter reads.
   </p>
 
   <hr />

--- a/index.html
+++ b/index.html
@@ -19,6 +19,21 @@
     <!-- Default to light theme -->
     <link id="themeStylesheet" rel="stylesheet" href="style.css?v1.2">
 
+    <!--
+        Apply the saved theme before the page paints, otherwise a dark-theme
+        user gets a white flash on every load. about.html reads the same key.
+    -->
+    <script>
+        (function () {
+            try {
+                if (localStorage.getItem('tpcraw-theme') === 'dark') {
+                    document.getElementById('themeStylesheet')
+                            .setAttribute('href', 'style_dark.css');
+                }
+            } catch (e) { /* storage blocked (private mode) — stay on light */ }
+        })();
+    </script>
+
     <!-- Example CSS for new vertical dividers, switch, and icon button -->
     <style>
 
@@ -299,16 +314,33 @@
 
     <!-- Script to handle theme toggling and about button -->
     <script>
+        // Shared with about.html so the two pages agree on the theme.
+        const THEME_STORAGE_KEY = "tpcraw-theme";
+
         const themeToggleCheckbox = document.getElementById("themeToggle");
         const themeStylesheet = document.getElementById("themeStylesheet");
 
-        // Switch to dark theme if checked; otherwise light
-        themeToggleCheckbox.addEventListener("change", () => {
-            if (themeToggleCheckbox.checked) {
-                themeStylesheet.setAttribute("href", "style_dark.css");
-            } else {
-                themeStylesheet.setAttribute("href", "style.css");
+        function readStoredTheme() {
+            try {
+                return localStorage.getItem(THEME_STORAGE_KEY);
+            } catch (e) {
+                return null; // storage blocked
             }
+        }
+
+        // Switch to dark theme if checked; otherwise light
+        function applyTheme(isDark) {
+            themeStylesheet.setAttribute("href", isDark ? "style_dark.css" : "style.css");
+            try {
+                localStorage.setItem(THEME_STORAGE_KEY, isDark ? "dark" : "light");
+            } catch (e) { /* storage blocked — theme just won't persist */ }
+        }
+
+        // The <head> script already applied the saved theme; catch the switch up.
+        themeToggleCheckbox.checked = readStoredTheme() === "dark";
+
+        themeToggleCheckbox.addEventListener("change", () => {
+            applyTheme(themeToggleCheckbox.checked);
         });
 
         // About button click

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         Chart.register(ChartZoom);
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
-    <script type="module" src="script.js?v=1.8"></script>
+    <script type="module" src="script.js?v=1.9"></script>
 
     <!-- Default to light theme -->
     <link id="themeStylesheet" rel="stylesheet" href="style.css?v1.2">
@@ -86,6 +86,12 @@
             gap: 1rem;
         }
     </style>
+
+    <!--
+        Theme-agnostic responsive layer. Must stay LAST so its rules win over
+        whichever theme sheet is loaded into #themeStylesheet above.
+    -->
+    <link rel="stylesheet" href="responsive.css?v=1.0">
 </head>
 
 <body>
@@ -176,7 +182,9 @@
 
             <div id="sentimentPieBox" class="dashboard-box-large">
                 <div class="postCount-title-large">Sentiments Distribution</div>
-                <canvas id="sentimentPieChart"></canvas>
+                <div class="chart-canvas-wrap chart-canvas-wrap--square">
+                    <canvas id="sentimentPieChart"></canvas>
+                </div>
             </div>
         </div>
 
@@ -193,7 +201,9 @@
 
             <!-- Weighted Sentiments Section -->
             <section id="weightedTab" class="chart-section tab-content">
-                <canvas id="weightedSentimentChart"></canvas>
+                <div class="chart-canvas-wrap">
+                    <canvas id="weightedSentimentChart"></canvas>
+                </div>
                 <div class="chart-controls">
                     <button id="resetZoomWeightedBtn">Reset Zoom</button>
                     <span class="zoom-instructions">To zoom, click and drag on the chart or pinch on touch devices.</span>
@@ -203,7 +213,9 @@
 
             <!-- Stacked Sentiments Section -->
             <section id="stackedTab" class="chart-section tab-content active">
-                <canvas id="stackedSentimentChart"></canvas>
+                <div class="chart-canvas-wrap">
+                    <canvas id="stackedSentimentChart"></canvas>
+                </div>
                 <div class="chart-controls">
                     <button id="resetZoomStackedBtn">Reset Zoom</button>
                     <span class="zoom-instructions">To zoom, click and drag on the chart or pinch on touch devices.</span>
@@ -213,7 +225,9 @@
 
             <!-- Total Comments Section -->
             <section id="totalCommentsTab" class="chart-section tab-content">
-                <canvas id="totalCommentsChart"></canvas>
+                <div class="chart-canvas-wrap">
+                    <canvas id="totalCommentsChart"></canvas>
+                </div>
                 <div class="chart-controls">
                     <button id="resetZoomTotalCommentsBtn">Reset Zoom</button>
                     <span class="zoom-instructions">To zoom, click and drag on the chart or pinch on touch devices.</span>
@@ -223,7 +237,9 @@
 
             <!-- Engagement Scores Section -->
             <section id="engagementTab" class="chart-section tab-content">
-                <canvas id="engagementScoreChart"></canvas>
+                <div class="chart-canvas-wrap">
+                    <canvas id="engagementScoreChart"></canvas>
+                </div>
                 <div class="chart-controls">
                     <button id="resetZoomEngagementBtn">Reset Zoom</button>
                     <span class="zoom-instructions">To zoom, click and drag on the chart or pinch on touch devices.</span>
@@ -250,13 +266,17 @@
 
             <!-- Authors Tab -->
             <section id="authorsTab" class="chart-section tab-content">
-                <canvas id="authorsChart"></canvas>
+                <div class="chart-canvas-wrap">
+                    <canvas id="authorsChart"></canvas>
+                </div>
                 <p class="chart-description">This chart displays the top 10 authors with a stacked breakdown of positive and negative sentiment counts.</p>
             </section>
 
             <!-- Time Series Tab -->
             <section id="timeSeriesTab" class="chart-section tab-content">
-                <canvas id="timeSeriesChart"></canvas>
+                <div class="chart-canvas-wrap chart-canvas-wrap--tall">
+                    <canvas id="timeSeriesChart"></canvas>
+                </div>
                 <div class="chart-controls">
                     <button id="resetZoomTimeSeriesBtn">Reset Zoom</button>
                     <span class="zoom-instructions">To zoom, click and drag on the chart or pinch on touch devices.</span>

--- a/responsive.css
+++ b/responsive.css
@@ -1,0 +1,487 @@
+/* =============================================================
+   responsive.css — device-agnostic layout layer
+   -------------------------------------------------------------
+   Loaded AFTER style.css / style_dark.css (see index.html) so it
+   applies to BOTH themes without duplicating any colour rules.
+   Only layout, sizing and touch-affordance concerns belong here;
+   keep colours in the theme sheets.
+
+   Breakpoints
+     <= 1024px  tablets / small laptops  -> single column dashboard
+     <=  768px  phones (landscape)       -> stacked controls, static footer
+     <=  480px  phones (portrait)        -> tightest spacing
+   ============================================================= */
+
+/* -------------------------------------------------------------
+   1. Global guards against horizontal overflow
+   ------------------------------------------------------------- */
+
+html {
+  /* Stop iOS/Android silently inflating text in rotated layouts. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+img,
+canvas,
+video,
+iframe {
+  max-width: 100%;
+}
+
+/* Long Reddit titles / URLs must never widen the page. */
+.post-details-title,
+.body-content,
+.comment-body,
+.post-body-excerpt,
+.post-list-table td {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* -------------------------------------------------------------
+   2. Fluid page gutters
+   The theme sheets use `max-width: 1400px; margin: 20px auto`, which
+   leaves content flush against the screen edge below 1400px.
+   ------------------------------------------------------------- */
+
+.controls,
+.main-container {
+  width: min(100% - 2rem, 1400px);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* -------------------------------------------------------------
+   3. Chart canvas sizing
+
+   Chart.js is switched to `maintainAspectRatio: false` in script.js,
+   which means the canvas fills its parent. These wrappers are what
+   give every chart a definite, viewport-relative height instead of
+   the old width/2 aspect ratio that collapsed to ~150px on a phone.
+   ------------------------------------------------------------- */
+
+.chart-canvas-wrap {
+  position: relative;
+  width: 100%;
+}
+
+/* NOTE: every height rule, here and in the media queries below, excludes
+   --square. That wrapper must keep `height: auto` at all breakpoints because
+   Chart.js derives the pie's height from its own 1:1 aspect ratio; a fixed
+   parent height would fight it. */
+.chart-canvas-wrap:not(.chart-canvas-wrap--square) {
+  height: clamp(300px, 48vh, 520px);
+}
+
+/* Time series carries a large multi-category legend, so give it more room. */
+.chart-canvas-wrap--tall {
+  height: clamp(360px, 58vh, 620px);
+}
+
+/* Pie chart keeps its own 1:1 ratio (maintainAspectRatio stays true). */
+.chart-canvas-wrap--square {
+  height: auto;
+  width: 100%;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.chart-canvas-wrap > canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.chart-canvas-wrap--square > canvas {
+  height: auto;
+}
+
+/* -------------------------------------------------------------
+   4. Tables inside narrow containers scroll rather than overflow
+   ------------------------------------------------------------- */
+
+#topPosts #postListContainer {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* =============================================================
+   <= 1024px — tablets and small laptops
+   ============================================================= */
+
+@media (max-width: 1024px) {
+
+  /* Dashboard becomes a single column: stats on top, charts below. */
+  .main-container {
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  /* `min-width` on flex children is what forces horizontal overflow
+     on narrow screens — reset it. */
+  .left-div,
+  .right-div {
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
+  }
+
+  /* Stat cards sit side by side rather than in a tall stack. */
+  .left-div {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px;
+    align-items: start;
+  }
+
+  /* Row 1: subreddit picker | Posts+Comments counters
+     Row 2: average sentiment (full width)
+     Row 3: pie chart (full width) */
+  .left-div .subreddit-select-container,
+  .left-div .post-comments-count-container {
+    grid-column: span 1;
+  }
+
+  .left-div #avgWeightedScoreBox,
+  .left-div #sentimentPieBox {
+    grid-column: 1 / -1;
+  }
+
+  /* Tabs become a horizontally swipeable strip instead of wrapping
+     into four ragged rows. */
+  .tab-container {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    justify-content: flex-start;
+    padding-left: 0;
+    padding-right: 0;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x proximity;
+  }
+
+  .tab-button {
+    flex: 0 0 auto;
+    white-space: nowrap;
+    scroll-snap-align: start;
+    /* Negative margin would be clipped by the scroll container. */
+    margin-bottom: 0;
+  }
+
+  /* Gutters now come from .main-container, so drop the per-section ones. */
+  .chart-section {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+/* =============================================================
+   <= 768px — phones
+   ============================================================= */
+
+@media (max-width: 768px) {
+
+  header {
+    padding: 12px 10px;
+  }
+
+  header h1 {
+    font-size: clamp(1.15rem, 4.6vw, 1.7rem);
+    line-height: 1.25;
+  }
+
+  /* ---- Controls bar: one full-width group per row ---- */
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 12px;
+    padding: 14px;
+  }
+
+  /* Re-purpose the vertical rules as horizontal group separators. */
+  .controls .vertical-divider {
+    width: 100%;
+    height: 1px;
+    margin: 2px 0;
+  }
+
+  .controls .date-range {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 8px 10px;
+    align-items: center;
+  }
+
+  .controls .date-range input[type="date"] {
+    width: 100%;
+  }
+
+  .controls .controls-middle-group {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 16px;
+  }
+
+  .controls .controls-middle-group #filter-btn {
+    flex: 1 1 100%;
+  }
+
+  .controls .keyword-search {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .controls .keyword-search input[type="text"] {
+    min-width: 0;
+  }
+
+  .theme-about-container {
+    justify-content: flex-end;
+  }
+
+  /* ---- Touch affordances ----
+     44px is the minimum comfortable tap target on touch screens. */
+  .controls button,
+  .chart-controls button,
+  .close-drawer-btn,
+  .pdf-export-btn,
+  .view-full-post-btn {
+    min-height: 44px;
+  }
+
+  .icon-button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .controls input[type="checkbox"] {
+    width: 20px;
+    height: 20px;
+  }
+
+  /* iOS zooms the page when a focused input is under 16px. */
+  .controls .date-range input[type="date"],
+  .controls .keyword-search input[type="text"],
+  #subreddit-select,
+  #topPosts select {
+    font-size: 16px;
+  }
+
+  /* ---- Charts ---- */
+  .chart-canvas-wrap:not(.chart-canvas-wrap--square) {
+    height: clamp(300px, 52vh, 420px);
+  }
+
+  .chart-canvas-wrap--tall {
+    height: clamp(340px, 62vh, 500px);
+  }
+
+  .chart-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    margin: 14px 0;
+  }
+
+  .chart-controls button {
+    width: 100%;
+  }
+
+  .chart-controls span {
+    text-align: center;
+    font-size: 0.85em;
+  }
+
+  .chart-section {
+    padding: 12px 10px;
+    margin-bottom: 18px;
+  }
+
+  .chart-section h3 {
+    font-size: 1.3em;
+    margin-bottom: 14px;
+  }
+
+  /* ---- Top 10 table ---- */
+  .post-list-table {
+    /* Narrower than this and the four columns become unreadable, so
+       scroll the table instead of squashing it. */
+    min-width: 520px;
+  }
+
+  .post-list-table th,
+  .post-list-table td {
+    padding: 8px;
+    font-size: 0.9em;
+  }
+
+  /* ---- Post details modal: full screen on a phone ---- */
+  #post-details-container {
+    top: 0;
+    left: 0;
+    width: 100%;
+    max-width: none;
+    height: 100vh;
+    height: 100dvh;
+    border-radius: 0;
+    transform: translate(0, 0) scale(0.96);
+  }
+
+  #post-details-container.open {
+    transform: translate(0, 0) scale(1);
+  }
+
+  .modal-nav-container {
+    padding: 10px 12px;
+  }
+
+  .post-details-wrapper,
+  .category-date-details-wrapper,
+  .author-details-wrapper,
+  .search-results-wrapper {
+    padding: 16px 14px;
+    border-radius: 0;
+  }
+
+  .post-details-title,
+  .category-date-title,
+  .author-details-title,
+  .search-results-title {
+    font-size: 1.3em;
+  }
+
+  .category-post-item,
+  .category-comment-item,
+  .author-post-item,
+  .author-comment-item,
+  .search-item-card,
+  .post-details-comment {
+    padding: 12px;
+  }
+
+  /* ---- Footer: fixed bars eat far too much of a phone screen ---- */
+  body {
+    padding-bottom: 0;
+  }
+
+  footer {
+    position: static;
+    margin-top: 24px;
+    padding: 14px 16px;
+    padding-bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  }
+}
+
+/* =============================================================
+   <= 600px — phones in portrait
+   ============================================================= */
+
+@media (max-width: 600px) {
+
+  /* Two stat columns no longer fit comfortably. */
+  .left-div {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .left-div .subreddit-select-container,
+  .left-div #avgWeightedScoreBox,
+  .left-div #sentimentPieBox {
+    grid-column: 1 / -1;
+  }
+
+  /* Posts / Comments stay paired — they are short enough. */
+  .left-div .post-comments-count-container {
+    gap: 12px;
+    flex-wrap: nowrap;
+  }
+}
+
+/* =============================================================
+   <= 480px — tightest spacing
+   ============================================================= */
+
+@media (max-width: 480px) {
+
+  .controls,
+  .main-container {
+    width: min(100% - 1rem, 1400px);
+  }
+
+  .dashboard-box .postCount-number {
+    font-size: 1.8em;
+  }
+
+  .dashboard-box-wide .postCount-number-wide {
+    font-size: 2.2em;
+  }
+
+  .left-div .subreddit-select-container .postCount-title-large,
+  .dashboard-box-large .postCount-title-large {
+    margin-bottom: 12px;
+    font-size: 1.05em;
+  }
+
+  .tab-button {
+    padding: 12px 10px;
+    font-size: 0.82em;
+  }
+
+  .chart-canvas-wrap:not(.chart-canvas-wrap--square) {
+    height: clamp(280px, 50vh, 380px);
+  }
+
+  .chart-description {
+    font-size: 0.88em;
+    line-height: 1.6;
+  }
+}
+
+/* =============================================================
+   Short landscape phones — reclaim vertical space
+   ============================================================= */
+
+@media (max-height: 500px) and (orientation: landscape) {
+
+  header {
+    padding: 6px 10px;
+  }
+
+  header h1 {
+    font-size: 1.1rem;
+  }
+
+  .chart-canvas-wrap:not(.chart-canvas-wrap--square),
+  .chart-canvas-wrap--tall {
+    height: 78vh;
+  }
+}
+
+/* =============================================================
+   Accessibility / print
+   ============================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  #post-details-container,
+  .tab-button,
+  .controls button,
+  .chart-controls button {
+    transition: none !important;
+  }
+}
+
+@media print {
+  .controls,
+  .tab-container,
+  .chart-controls,
+  #drawer-overlay,
+  footer {
+    display: none !important;
+  }
+
+  .main-container {
+    display: block;
+  }
+}

--- a/script.js
+++ b/script.js
@@ -17,6 +17,86 @@ import {
 
 const MAX_LABEL_LENGTH = 30;
 
+// --- Responsive chart helpers -------------------------------------------
+// Charts are sized by their .chart-canvas-wrap parent (see responsive.css)
+// because maintainAspectRatio is false. What still has to adapt in JS is the
+// content of the chart: label length, tick density, font sizes and which
+// zoom gestures make sense for the input device.
+
+const MOBILE_BREAKPOINT = 768;          // keep in sync with responsive.css
+const MAX_LABEL_LENGTH_MOBILE = 14;
+
+const isMobileViewport = () => window.innerWidth <= MOBILE_BREAKPOINT;
+
+// Touch screens have no modifier keys and no meaningful drag-to-zoom.
+const isTouchDevice = () =>
+  window.matchMedia('(pointer: coarse)').matches || 'ontouchstart' in window;
+
+function truncateChartLabel(title) {
+  const limit = isMobileViewport() ? MAX_LABEL_LENGTH_MOBILE : MAX_LABEL_LENGTH;
+  if (title.length > limit) {
+    return title.slice(0, limit) + '…';
+  }
+  // Desktop pads short titles so the rotated labels line up; on a phone that
+  // padding just wastes horizontal space.
+  return isMobileViewport() ? title : title.padStart(limit, ' ');
+}
+
+// Category (post-title / author) axis. autoSkip keeps the axis readable when
+// dozens of bars are squeezed into a phone-width canvas.
+function responsiveCategoryTicks(extra = {}) {
+  const mobile = isMobileViewport();
+  return {
+    autoSkip: true,
+    maxTicksLimit: mobile ? 8 : 30,
+    maxRotation: mobile ? 90 : 60,
+    minRotation: mobile ? 90 : 60,
+    align: 'center',
+    font: { size: mobile ? 9 : 12 },
+    ...extra
+  };
+}
+
+function responsiveChartTitle(text) {
+  const mobile = isMobileViewport();
+  return {
+    display: true,
+    text: text,
+    align: 'start',
+    font: { size: mobile ? 13 : 18, weight: '600', family: 'Arial, sans-serif' },
+    color: '#333',
+    padding: { top: mobile ? 4 : 10, bottom: mobile ? 10 : 20 }
+  };
+}
+
+// On touch: single-finger horizontal drag pans (mode 'x' lets vertical swipes
+// fall through to page scrolling) and pinch zooms. Drag-to-zoom stays a
+// mouse-only gesture, otherwise it fights the pan gesture on a phone.
+function responsiveZoomOptions() {
+  const touch = isTouchDevice();
+  return {
+    pan: { enabled: true, mode: 'x', modifierKey: touch ? null : 'ctrl' },
+    zoom: {
+      drag: { enabled: !touch },
+      pinch: { enabled: true },
+      mode: 'x'
+    }
+  };
+}
+
+function responsiveLegend(extra = {}) {
+  const mobile = isMobileViewport();
+  return {
+    position: mobile ? 'bottom' : 'top',
+    labels: {
+      boxWidth: mobile ? 10 : 40,
+      padding: mobile ? 8 : 10,
+      font: { size: mobile ? 10 : 12 }
+    },
+    ...extra
+  };
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   // --- 1. MODAL ELEMENTS ---
   const drawer = document.getElementById('post-details-container');
@@ -178,6 +258,67 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Note: Hover effects are better handled purely in CSS with :hover pseudo-class
   // Removing JS hover effects for tabs and reset buttons as they should be in CSS.
 
+  //--------------------RESPONSIVE RE-RENDER
+  // The CSS handles the box the chart lives in, but label length, tick density
+  // and legend placement are baked in at render time. Re-render when the
+  // viewport crosses the mobile breakpoint (rotating a phone, resizing a
+  // window) so those stay correct without a page reload.
+  let wasMobileViewport = isMobileViewport();
+  let viewportResizeTimer = null;
+
+  function rerenderChartsForViewport() {
+    if (!Array.isArray(allPostsData) || allPostsData.length === 0) return;
+    try {
+      // These render from data already in memory — no extra Firestore reads.
+      renderSentimentPieChart(allPostsData);
+      renderWeightedSentimentChart(allPostsData);
+      renderSentimentStackChart(allPostsData);
+      renderEngagementScoreChart(allPostsData);
+      renderCommentsCountChart(allPostsData);
+
+      // Authors + time series would need a refetch to re-render, so just patch
+      // the size-dependent options in place.
+      const sizedCharts = [window.authorsChartInstance, timeSeriesChart];
+      sizedCharts.forEach(chart => {
+        if (!chart) return;
+        Object.assign(chart.options.plugins.title, responsiveChartTitle(chart.options.plugins.title.text));
+        if (chart.options.plugins.legend) {
+          chart.options.plugins.legend.position = isMobileViewport() ? 'bottom' : 'top';
+          chart.options.plugins.legend.labels.boxWidth = isMobileViewport() ? 10 : 40;
+        }
+        chart.update('none');
+      });
+
+      // The active tab is the only one with a measurable box; nudge it.
+      const activeChartSection = document.querySelector('.chart-section.active');
+      if (activeChartSection) {
+        const canvas = activeChartSection.querySelector('canvas');
+        const instance = canvas && Chart.getChart(canvas);
+        if (instance) instance.resize();
+      }
+    } catch (err) {
+      console.error("Error re-rendering charts for viewport change:", err);
+    }
+  }
+
+  window.addEventListener('resize', () => {
+    clearTimeout(viewportResizeTimer);
+    viewportResizeTimer = setTimeout(() => {
+      const nowMobile = isMobileViewport();
+      if (nowMobile === wasMobileViewport) return; // only on a real breakpoint change
+      wasMobileViewport = nowMobile;
+      rerenderChartsForViewport();
+    }, 200);
+  });
+
+  // Zoom gestures differ by input device (see responsiveZoomOptions), so the
+  // on-screen hint has to describe what this device can actually do.
+  document.querySelectorAll('.zoom-instructions').forEach(el => {
+    el.textContent = isTouchDevice()
+      ? 'Pinch to zoom, drag sideways to pan, and tap a bar for details.'
+      : 'To zoom, click and drag on the chart. Hold Ctrl and drag to pan.';
+  });
+
   // --------------------------------------------------------------
   // FETCH FIRESTORE POSTS - with filters for subreddit & checkboxes
   // --------------------------------------------------------------
@@ -320,9 +461,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       window.sentimentPieChartInstance.destroy();
     }
 
-    ctx.canvas.width = 260; // Keep explicit sizing if needed for layout
-    ctx.canvas.height = 260;
-
     window.sentimentPieChartInstance = new Chart(ctx, {
       type: 'pie',
       data: {
@@ -333,7 +471,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         }]
       },
       options: {
-        responsive: false, // Keep false if explicit size is intended
+        // Sized by .chart-canvas-wrap--square; stays 1:1 on every screen.
+        responsive: true,
+        maintainAspectRatio: true,
+        aspectRatio: 1,
         plugins: {
           legend: {
             display: false,
@@ -353,16 +494,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Chart 2: WEIGHTED SENTIMENT
   // ---------------------------------------------
    function renderWeightedSentimentChart(data) {
-    const labels = data.map(post => {
-        const { title } = post;
-        // Keep label truncation logic
-        if (title.length > MAX_LABEL_LENGTH) {
-            return title.slice(0, MAX_LABEL_LENGTH) + '…';
-        } else {
-            // Padding logic might be better handled via CSS if possible, but keep if needed
-            return title.padStart(MAX_LABEL_LENGTH, ' ');
-        }
-    });
+    const labels = data.map(post => truncateChartLabel(post.title));
     const weightedScores = data.map(item => item.weightedSentimentScore);
 
     // Bar color logic remains in JS as it's data-dependent
@@ -387,23 +519,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         },
         options: { // Chart options remain largely the same
             responsive: true,
+            maintainAspectRatio: false, // height comes from .chart-canvas-wrap
             plugins: {
-                title: { // Title styling can often be done via Chart.js options
-                    display: true,
-                    text: 'Weighted Sentiment Breakdown by Post',
-                    align: 'start',
-                    font: { size: 18, weight: '600', family: 'Arial, sans-serif' },
-                    color: '#333',
-                    padding: { top: 10, bottom: 20 }
-                },
-                zoom: { // Zoom plugin configuration
-                    pan: { enabled: true, mode: 'x', modifierKey: 'ctrl' },
-                    zoom: { drag: { enabled: true }, pinch: { enabled: true }, mode: 'x' }
-                }
+                title: responsiveChartTitle('Weighted Sentiment Breakdown by Post'),
+                legend: responsiveLegend(),
+                zoom: responsiveZoomOptions()
             },
             scales: {
-                x: { ticks: { maxRotation: 60, minRotation: 60, align: 'center' } },
-                y: { beginAtZero: true }
+                x: { ticks: responsiveCategoryTicks() },
+                y: { beginAtZero: true, ticks: { font: { size: isMobileViewport() ? 10 : 12 } } }
             },
             onClick: (evt, elements) => { // Click handler remains
                 if (elements.length > 0) {
@@ -420,14 +544,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Chart 3: RAW SENTIMENT STACK (Stacked Sentiment)
   // ---------------------------------------------
   function renderSentimentStackChart(data) {
-      const labels = data.map(post => {
-          const { title } = post;
-          if (title.length > MAX_LABEL_LENGTH) {
-              return title.slice(0, MAX_LABEL_LENGTH) + '…';
-          } else {
-              return title.padStart(MAX_LABEL_LENGTH, ' ');
-          }
-      });
+      const labels = data.map(post => truncateChartLabel(post.title));
       const positiveData = data.map(post => post.totalPositiveSentiments);
       const negativeData = data.map(post => post.totalNegativeSentiments);
 
@@ -458,27 +575,19 @@ document.addEventListener('DOMContentLoaded', async () => {
           },
           options: { // Options remain largely the same
               responsive: true,
+              maintainAspectRatio: false, // height comes from .chart-canvas-wrap
               interaction: {
                   mode: 'index', // This detects clicks anywhere on the vertical axis of the bar
                   intersect: false // Allows clicking even if the mouse isn't directly touching a colored bar
               },
               plugins: {
-                  title: {
-                      display: true,
-                      text: 'Sentiment Breakdown by Post',
-                      align: 'start',
-                      font: { size: 18, weight: '600', family: 'Arial, sans-serif' },
-                      color: '#333',
-                      padding: { top: 10, bottom: 20 }
-                  },
-                  zoom: {
-                      pan: { enabled: true, mode: 'x', modifierKey: 'ctrl' },
-                      zoom: { drag: { enabled: true }, pinch: { enabled: true }, mode: 'x' }
-                  }
+                  title: responsiveChartTitle('Sentiment Breakdown by Post'),
+                  legend: responsiveLegend(),
+                  zoom: responsiveZoomOptions()
               },
               scales: {
-                  x: { stacked: true, ticks: { maxRotation: 60, minRotation: 60, align: 'center' } },
-                  y: { stacked: true, beginAtZero: true }
+                  x: { stacked: true, ticks: responsiveCategoryTicks() },
+                  y: { stacked: true, beginAtZero: true, ticks: { font: { size: isMobileViewport() ? 10 : 12 } } }
               },
               onClick: (evt, elements) => { // Click handler remains
                   if (elements.length > 0) {
@@ -495,14 +604,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Chart 4: ENGAGEMENT SCORE
   // ---------------------------------------------
   function renderEngagementScoreChart(data) {
-      const labels = data.map(post => {
-          const { title } = post;
-          if (title.length > MAX_LABEL_LENGTH) {
-              return title.slice(0, MAX_LABEL_LENGTH) + '…';
-          } else {
-              return title.padStart(MAX_LABEL_LENGTH, ' ');
-          }
-      });
+      const labels = data.map(post => truncateChartLabel(post.title));
       const engagementScores = data.map(item => item.engagementScore);
 
       // Color remains here
@@ -525,23 +627,15 @@ document.addEventListener('DOMContentLoaded', async () => {
           },
           options: { // Options remain largely the same
               responsive: true,
+              maintainAspectRatio: false, // height comes from .chart-canvas-wrap
               plugins: {
-                  title: {
-                      display: true,
-                      text: 'Engagement Score per Post',
-                      align: 'start',
-                      font: { size: 18, weight: '600', family: 'Arial, sans-serif' },
-                      color: '#333',
-                      padding: { top: 10, bottom: 20 }
-                  },
-                  zoom: {
-                      pan: { enabled: true, mode: 'x', modifierKey: 'ctrl' },
-                      zoom: { drag: { enabled: true }, pinch: { enabled: true }, mode: 'x' }
-                  }
+                  title: responsiveChartTitle('Engagement Score per Post'),
+                  legend: responsiveLegend(),
+                  zoom: responsiveZoomOptions()
               },
               scales: {
-                  x: { ticks: { maxRotation: 60, minRotation: 60, align: 'center' } },
-                  y: { beginAtZero: true }
+                  x: { ticks: responsiveCategoryTicks() },
+                  y: { beginAtZero: true, ticks: { font: { size: isMobileViewport() ? 10 : 12 } } }
               },
               onClick: (evt, elements) => { // Click handler remains
                   if (elements.length > 0) {
@@ -558,14 +652,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Chart 5: TOTAL COMMENTS
   // ---------------------------------------------
   function renderCommentsCountChart(data) {
-      const labels = data.map(post => {
-          const { title } = post;
-          if (title.length > MAX_LABEL_LENGTH) {
-              return title.slice(0, MAX_LABEL_LENGTH) + '…';
-          } else {
-              return title.padStart(MAX_LABEL_LENGTH, ' ');
-          }
-      });
+      const labels = data.map(post => truncateChartLabel(post.title));
       const totalComments = data.map(item => item.totalComments);
 
       // Color remains here
@@ -588,23 +675,15 @@ document.addEventListener('DOMContentLoaded', async () => {
           },
           options: { // Options remain largely the same
               responsive: true,
+              maintainAspectRatio: false, // height comes from .chart-canvas-wrap
               plugins: {
-                  title: {
-                      display: true,
-                      text: 'Comments per Post',
-                      align: 'start',
-                      font: { size: 18, weight: '600', family: 'Arial, sans-serif' },
-                      color: '#333',
-                      padding: { top: 10, bottom: 20 }
-                  },
-                  zoom: {
-                      pan: { enabled: true, mode: 'x', modifierKey: 'ctrl' },
-                      zoom: { drag: { enabled: true }, pinch: { enabled: true }, mode: 'x' }
-                  }
+                  title: responsiveChartTitle('Comments per Post'),
+                  legend: responsiveLegend(),
+                  zoom: responsiveZoomOptions()
               },
               scales: {
-                  x: { ticks: { maxRotation: 60, minRotation: 60, align: 'center' } },
-                  y: { beginAtZero: true }
+                  x: { ticks: responsiveCategoryTicks() },
+                  y: { beginAtZero: true, ticks: { font: { size: isMobileViewport() ? 10 : 12 } } }
               },
               onClick: (evt, elements) => { // Click handler remains
                   if (elements.length > 0) {
@@ -957,15 +1036,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       },
       options: { // Options remain
         responsive: true,
+        maintainAspectRatio: false, // height comes from .chart-canvas-wrap
         plugins: {
-          title: {
-            display: true,
-            text: 'Top 10 Authors with Most Negative Sentiments',
-            align: 'start',
-            font: { size: 18, weight: '600', family: 'Arial, sans-serif' },
-            color: '#333',
-            padding: { top: 10, bottom: 20 }
-          },
+          title: responsiveChartTitle('Top 10 Authors with Most Negative Sentiments'),
+          legend: responsiveLegend(),
           tooltip: {
             callbacks: {
               label: function(context) {
@@ -975,8 +1049,8 @@ document.addEventListener('DOMContentLoaded', async () => {
           }
         },
         scales: {
-          x: { stacked: true, ticks: { maxRotation: 60, minRotation: 60, align: 'center' } },
-          y: { stacked: true, beginAtZero: true }
+          x: { stacked: true, ticks: responsiveCategoryTicks() },
+          y: { stacked: true, beginAtZero: true, ticks: { font: { size: isMobileViewport() ? 10 : 12 } } }
         },
         onClick: (evt, elements) => { // Click handler remains
           if (elements.length > 0) {
@@ -1152,20 +1226,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         data: { datasets: datasets },
         options: { // Options remain largely the same
             responsive: true,
+            maintainAspectRatio: false, // height comes from .chart-canvas-wrap--tall
             plugins: {
-                title: {
-                    display: true,
-                    text: 'Time Series of Average Sentiment by Category',
-                    align: 'start',
-                    font: { size: 18, weight: '600' }
-                },
-                zoom: {
-                    pan: { enabled: true, mode: 'x', modifierKey: 'ctrl' },
-                    zoom: { drag: { enabled: true }, pinch: { enabled: true }, mode: 'x' }
-                },
+                title: responsiveChartTitle('Time Series of Average Sentiment by Category'),
+                zoom: responsiveZoomOptions(),
                 tooltip: { mode: 'index', intersect: false },
                 legend: { // Legend customization remains
+                    // Many categories: move the legend below the plot on phones
+                    // so it stops eating the chart's width.
+                    position: isMobileViewport() ? 'bottom' : 'top',
                     labels: {
+                        boxWidth: isMobileViewport() ? 10 : 40,
+                        padding: isMobileViewport() ? 6 : 10,
+                        font: { size: isMobileViewport() ? 10 : 12 },
                         generateLabels: function(chart) {
                             const dsets = chart.data.datasets;
                             const seenCategories = {};
@@ -1208,11 +1281,19 @@ document.addEventListener('DOMContentLoaded', async () => {
                 x: {
                     type: 'time',
                     time: { parser: 'yyyy-MM-dd', unit: 'day', displayFormats: { day: 'MMM d' } },
-                    title: { display: true, text: 'Date' }
+                    // Axis titles are redundant on a phone-width chart.
+                    title: { display: !isMobileViewport(), text: 'Date' },
+                    ticks: {
+                        autoSkip: true,
+                        maxTicksLimit: isMobileViewport() ? 5 : 12,
+                        maxRotation: isMobileViewport() ? 45 : 0,
+                        font: { size: isMobileViewport() ? 9 : 12 }
+                    }
                 },
                 y: {
                     min: -1.2, max: 1.2, beginAtZero: false,
-                    title: { display: true, text: 'Average Sentiment' }
+                    title: { display: !isMobileViewport(), text: 'Average Sentiment' },
+                    ticks: { font: { size: isMobileViewport() ? 9 : 12 } }
                 }
             },
             onClick: async (evt, elements) => { // Click handler remains


### PR DESCRIPTION
## Make the dashboard usable on phones and tablets

Charts were effectively invisible on a phone. Chart.js ran with `responsive: true`
but kept its default 2:1 aspect ratio, so on a ~360px screen each canvas was only
~160px tall — and 60°-rotated, 30-character post titles consumed nearly all of it,
leaving no visible plot area.

Two other things forced horizontal page overflow: `min-width: 300px` on `.right-div`
and `min-width: 280px` on `.left-div`.

### Layout

New **`responsive.css`**, loaded *after* the theme sheet, so one set of media queries
serves both light and dark themes rather than duplicating rules into `style.css` and
`style_dark.css`.

| Screen | Behaviour |
| --- | --- |
| Desktop (>1024px) | Unchanged two-column layout |
| Tablet (≤1024px) | Single column; summary cards become a grid; tab bar scrolls horizontally instead of wrapping into four ragged rows |
| Phone (≤768px) | Controls stack full width; footer becomes static (the fixed bar ate the viewport); post details modal goes full screen; Top 10 table scrolls |

### Charts

- Every canvas is wrapped in `.chart-canvas-wrap`, which supplies a viewport-relative
  height (`clamp(300px, 48vh, 520px)`); bar/line charts switch to
  `maintainAspectRatio: false`.
- The pie chart no longer hard-codes a 260×260 canvas with `responsive: false`.
- Label length, tick density (`autoSkip`), font sizes and legend placement adapt to
  the viewport.
- Rotating a phone across the breakpoint re-renders from `allPostsData` — **no extra
  Firestore reads**.

### Touch

- Drag-to-zoom is now mouse-only. On touch, horizontal drag pans and pinch zooms;
  because pan mode is `'x'`, vertical swipes still scroll the page.
- 44px minimum tap targets; 16px inputs to stop iOS zoom-on-focus.
- The on-screen zoom hint now describes the gestures the device actually supports.

Desktop rendering is intentionally near-identical — the tick/title/legend helpers
return the previous values above 768px.

---

## Refresh the About page

It still described a single-subreddit, light-only app, documented neither the
subreddit selector, keyword search, TP-Related filter, theme toggle nor PDF export,
and had no way back to the dashboard — a dead end on a phone.

- Intro and *About This App* now cover all seven polytechnic subreddits.
- New sections: **Select Subreddit** (full subreddit table, plus which filters apply
  where), **Keyword Search**, **Light & Dark Themes**, **Works on Any Device**.
- Date Range table gains the *TP-Related?* row; Post Details documents the
  *Download PDF* button.
- *Automated Data Collection* explains `subreddits.txt` and the
  `relatedToTemasekPoly` flag behind the TP-Related filter.
- Sticky **Back to Dashboard** bar.

---

## Bug found along the way: the theme toggle never persisted

It only swapped the stylesheet `href` in memory, so **every reload reset the dashboard
to light**. Linking the About page to the toggle required fixing this first.

- The toggle now writes `tpcraw-theme` to `localStorage`; the checkbox syncs on load.
- Both pages apply the stored theme from a `<head>` script **before first paint**, so
  dark-theme users no longer get a white flash.
- `about.html` gains a dark palette via additive `:root[data-theme="dark"]` overrides,
  leaving the light styles untouched.
- `localStorage` access is wrapped in `try`/`catch` — under private browsing the theme
  works for the session but isn't remembered.

**Behaviour change:** the dashboard now remembers dark mode across visits. Unavoidable
given the About page has to follow the toggle, but calling it out explicitly.

---

## Testing

Validated: HTML tag balance on both pages, `script.js` parses as an ES module, all
assets serve 200.

**Not visually verified** — no browser was available in the environment this was
written in. Worth checking before merge:

```bash
python -m http.server 8000
```

1. DevTools device toolbar at 360×640, 390×844, 768×1024, and a landscape phone.
2. Toggle dark → click **?** → confirm About is dark with a readable back button →
   reload the dashboard → confirm it stays dark.
3. Whether `clamp(300px, 48vh, 520px)` feels right for chart height on desktop
   (slightly shorter than the old width/2).

Hard-refresh: `script.js` is bumped to `?v=1.9`, but `responsive.css` is new.

## Not included

Chart titles are hard-coded `color: '#333'`, which is near-invisible in dark theme.
Pre-existing theming bug, unrelated to device support — left for a separate PR.

## Files

| File | Change |
| --- | --- |
| `responsive.css` | New — 487 lines |
| `script.js` | Responsive chart helpers, `maintainAspectRatio`, touch gestures |
| `index.html` | Canvas wrappers, theme persistence, stylesheet link |
| `about.html` | Content refresh, dark theme, back-link, responsive block |
